### PR TITLE
Pass argument sequelize to initPools

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -5,9 +5,7 @@ var Pooling = require('generic-pool'),
     _ = require('lodash'),
     ConnectionManager;
 
-ConnectionManager = function (dialect, sequelize) {
-
-
+ConnectionManager = function (dialect) {
     this.onProcessExit = this.onProcessExit.bind(this); // Save a reference to the bound version so we can remove it with removeListener
     process.on('exit', this.onProcessExit);
 };


### PR DESCRIPTION
When using any dialect other then oracle the argument sequelize wasn't passed to ConnectionManager.initPools and therefore "TypeError: Cannot read property 'config' of undefined" was thrown.