### PR TITLE
 Pass argument sequelize to initPools

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -5,9 +5,7 @@ var Pooling = require('generic-pool'),
     _ = require('lodash'),
     ConnectionManager;
 
-ConnectionManager = function (dialect, sequelize) {
-
-
+ConnectionManager = function (dialect) {
     this.onProcessExit = this.onProcessExit.bind(this); // Save a reference to the bound version so we can remove it with removeListener
     process.on('exit', this.onProcessExit);
 };

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -9,8 +9,8 @@ var _ = require('lodash')
 
 var MssqlDialect = function(sequelize) {
   this.sequelize = sequelize;
-  this.connectionManager = new ConnectionManager(this, sequelize);
-  this.connectionManager.initPools();
+  this.connectionManager = new ConnectionManager(this);
+  this.connectionManager.initPools(sequelize);
   this.QueryGenerator = _.extend({}, QueryGenerator, {
     options: sequelize.options,
     _dialect: this,

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -9,8 +9,8 @@ var _ = require('lodash')
 
 var MysqlDialect = function(sequelize) {
   this.sequelize = sequelize;
-  this.connectionManager = new ConnectionManager(this, sequelize);
-  this.connectionManager.initPools();
+  this.connectionManager = new ConnectionManager(this);
+  this.connectionManager.initPools(sequelize);
   this.QueryGenerator = _.extend({}, QueryGenerator, {
     options: sequelize.options,
     _dialect: this,

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -9,8 +9,8 @@ var _ = require('lodash')
 
 var PostgresDialect = function(sequelize) {
   this.sequelize = sequelize;
-  this.connectionManager = new ConnectionManager(this, sequelize);
-  this.connectionManager.initPools();
+  this.connectionManager = new ConnectionManager(this);
+  this.connectionManager.initPools(sequelize);
 
   // parseDialectSpecificFields needs access to the pg lib in order to use its array parser. We cannot simply require pg in query.js since the user can specify another library path (such as pg-native etc)
   Query.prototype.parseDialectSpecificFields.lib = this.connectionManager.lib;


### PR DESCRIPTION
When using any dialect other then oracle the argument  sequelize wasn't passed to ConnectionManager.initPools and therefore  "TypeError: Cannot read property 'config' of undefined" was thrown.